### PR TITLE
add validate with regex

### DIFF
--- a/app/js/FactorialService.js
+++ b/app/js/FactorialService.js
@@ -1,11 +1,11 @@
 var FactorialService = (function () {
 
     var _results = [1, 1];
-
+      
+    var _reg = new RegExp('^[0-9]+$');   
+     
     function _isNumberValid(number) {
-        return (number !== undefined)
-            && (number > -1)
-            && (typeof(number) !== 'string');
+        return (_reg.test(number));        
     }
     
     function calculate(number) {

--- a/test/FactorialServiceSpec.js
+++ b/test/FactorialServiceSpec.js
@@ -15,10 +15,18 @@ describe('FactorialService.js', function() {
     
     it('should null if an invalid param was given', function() {
         expect(FactorialService.calculate(-1)).toBe(null);
-        expect(FactorialService.calculate("1")).toBe(null);
         expect(FactorialService.calculate("")).toBe(null);
         expect(FactorialService.calculate()).toBe(null);
     });
-        
+    
+    it('should return null for given params containing caracteres', function() {
+        expect(FactorialService.calculate('5xx')).toBe(null);
+        expect(FactorialService.calculate('x5x')).toBe(null);
+        expect(FactorialService.calculate('xx5')).toBe(null);
+    });
+    
+    it('should return null  if the given number is float', function() {
+        expect(FactorialService.calculate(5.5)).toBe(null);
+    });        
 });
     


### PR DESCRIPTION
I think the best practice is to add regex validation in the input, so users can not enter float numbers or characters.
